### PR TITLE
Add appeal chain analysis

### DIFF
--- a/src/collectors/consolidate.py
+++ b/src/collectors/consolidate.py
@@ -60,16 +60,20 @@ class DataConsolidator:
     
     def remove_duplicates(self, data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
-        Remove duplicatas de uma lista de processos com base no número do processo
+        Remove duplicatas mantendo entradas distintas para cada instância.
+        Decisões do mesmo processo em instâncias diferentes são preservadas.
         """
         unique_data = []
-        process_numbers: Set[str] = set()
-        
+        process_keys: Set[tuple] = set()
+
         for item in data:
             numero_processo = item.get('numero_processo', '')
-            if numero_processo and numero_processo not in process_numbers:
+            instancia = item.get('instancia', '')
+            key = (numero_processo, instancia)
+
+            if numero_processo and key not in process_keys:
                 unique_data.append(item)
-                process_numbers.add(numero_processo)
+                process_keys.add(key)
         
         logger.info(f"Removidas {len(data) - len(unique_data)} duplicatas de {len(data)} registros")
         return unique_data

--- a/src/processors/main.py
+++ b/src/processors/main.py
@@ -112,19 +112,8 @@ class DataProcessor:
         """
         processed_data = []
         
-        # Rastreia processos já analisados para evitar duplicidade
-        processed_processes = set()
-        
         for item in data:
             numero_processo = item.get('numero_processo', '')
-            
-            # Verifica se já processamos este número de processo
-            # Isso evita duplicidade de processos com múltiplas decisões
-            # Em caso de duplicidade, damos preferência a instâncias superiores
-            if numero_processo in processed_processes:
-                continue
-                
-            processed_processes.add(numero_processo)
             
             # Processa o texto da decisão usando NLP
             texto_analise = item.get('texto', '') + ' ' + item.get('ementa', '')


### PR DESCRIPTION
## Summary
- keep duplicate process numbers when processing
- dedupe consolidated data by process+instance instead of only process
- analyse appeal chains across instances and summarise in report
- expose appeal chain metrics on the dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68570c9886b48333b7a266ded164dfdd